### PR TITLE
add test with scalamock

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val core = project.in(file("core"))
   .settings(commonSettings)
   .settings(coreSettings)
 
-lazy val coreSettings = coreLibraryDependencies ++ Seq(
+lazy val coreSettings = coreLibraryDependencies ++ coreTestingLibraryDependencies ++ Seq(
   name := "TypesafeFluentLogger Core",
   moduleName := "typesafe-fluent-logger-core"
 )
@@ -21,6 +21,13 @@ lazy val coreSettings = coreLibraryDependencies ++ Seq(
 lazy val coreLibraryDependencies = Seq(
   libraryDependencies ++= Seq(
     "org.fluentd" %% "fluent-logger-scala"  % "0.7.0"
+  )
+)
+
+lazy val coreTestingLibraryDependencies = Seq(
+  libraryDependencies ++= Seq(
+    "org.scalatest" %% "scalatest"                   % "3.0.1"  % "test",
+    "org.scalamock" %% "scalamock-scalatest-support" % "3.5.0"  % "test"
   )
 )
 

--- a/core/src/test/scala/io/github/takayuky/fluent/FluentEncoderBasic.scala
+++ b/core/src/test/scala/io/github/takayuky/fluent/FluentEncoderBasic.scala
@@ -1,0 +1,38 @@
+package io.github.takayuky.fluent
+
+import io.github.takayuky.fluent.basic._
+import org.fluentd.logger.scala.FluentLogger
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.FlatSpec
+import scala.collection.Map
+
+class FluentEncoderBasic extends FlatSpec with MockFactory {
+
+  class Setup {
+    val underlyingMock = mock[FluentLogger]
+    val logger = TypesafeFluentLogger(underlyingMock)
+
+    val label = "label"
+    val time = 0L
+  }
+
+  behavior of "Basic instances"
+
+  it should "correctly encode basic instances" in new Setup {
+    val data = Map[String, FluentAcceptable](
+      "Boolean" -> true,
+      "Int" -> 1,
+      "Long" -> 1L,
+      "Double" -> 1d,
+      "Float" -> 1f,
+      "String" -> "hello",
+      "BigInt" -> BigInt(1),
+      "BigDecimal" -> BigDecimal(1),
+      "Some" -> Some(1),
+      "None" -> (None: Option[String])
+    )
+    (underlyingMock.log(_: String, _: Map[String, Any], _:Long)).expects(label, data.mapValues(_.v), time)
+
+    logger.log(label, data, time)
+  }
+}

--- a/core/src/test/scala/io/github/takayuky/fluent/FluentEncoderList.scala
+++ b/core/src/test/scala/io/github/takayuky/fluent/FluentEncoderList.scala
@@ -1,0 +1,32 @@
+package io.github.takayuky.fluent
+
+import io.github.takayuky.fluent.basic._
+import io.github.takayuky.fluent.list._
+import org.fluentd.logger.scala.FluentLogger
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.FlatSpec
+import scala.collection.Map
+
+class FluentEncoderList extends FlatSpec with MockFactory {
+
+  class Setup {
+    val underlyingMock = mock[FluentLogger]
+    val logger = TypesafeFluentLogger(underlyingMock)
+
+    val label = "label"
+    val time = 0L
+  }
+
+  behavior of "List instances"
+
+  it should "correctly encode list instances" in new Setup {
+    val data = Map[String, FluentAcceptable](
+      "List" -> List(1,2,3),
+      "Vector" -> Vector("hello", "world"),
+      "Set" -> Set[Option[Double]](Some(1d), None)
+    )
+    (underlyingMock.log(_: String, _: Map[String, Any], _:Long)).expects(label, data.mapValues(_.v), time)
+
+    logger.log(label, data, time)
+  }
+}


### PR DESCRIPTION
I chose ScalaTest and ScalaMock.

The reason why I picked ScalaMock over Mockito is based on an experience I worked on in the past.
ScalaMock is much more compatible with `Refined` than Mockito is.

I created a repository to show how Mockito is incompatible with Refined here.
https://github.com/takayuky/MockRefined/blob/master/src/test/scala/com/mockrefined/MockitoRefined.scala